### PR TITLE
Add codecov.io processing with travis-ci integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Corefile
 coredns
 kubectl
 go-test-tmpfile*
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,8 @@ script:
   - go test -tags etcd -race -bench=. ./...
   # Run kubernetes integration tests only if kubectl is available. i.e. If kubernetes was launched
   - ./contrib/kubernetes/testscripts/kubectl version && go test -v -tags k8s -race -bench=. -run 'TestK8sIntegration' ./test
+  # go cannot use test profile flag with multiple packages so we have to iterate, the following might be consolidated with the above steps.
+  - ./coverage.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e -x
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -race -coverprofile=profile.out -covermode=atomic $d
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
This fix adds the codecov.io process with travis-ci integration,
so that code coverage could be processed and displayed with codecov.io.

Since go cannot use test profile flag with multiple packages,
we have to iterate through packages with `coverage.sh`.

Some consolidation could be done by combining them into one `make test`.

Will do some consolidation in a follow up PR.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>